### PR TITLE
Add option to skip resetRelations callback and add function to unmark a record for destruction

### DIFF
--- a/addon/mixins/model.js
+++ b/addon/mixins/model.js
@@ -45,6 +45,10 @@ export default Ember.Mixin.create({
     this.set('_markedForDestruction', true);
   },
 
+  unmarkForDestruction() {
+    this.set('_markedForDestruction', false);
+  },
+
   jsonapiType() {
     return this.store
       .adapterFor(this.constructor.modelName)
@@ -57,7 +61,9 @@ export default Ember.Mixin.create({
   save(options = {}) {
     defaultOptions(options);
     let promise = this._super(...arguments);
-    promise.then(resetRelations);
+    if (options.resetRelations === true) {
+      promise.then(resetRelations);
+    }
     return promise;
   }
 });


### PR DESCRIPTION
The first change is to make use of the `options.resetRelations` optional argument to `save()`.
We are running into issues trying to delete a model with relationships. Calling `destroyRecord()` results in an error since `serialize()` is never called and `__recordsJustSaved` is never set, causing [this line](https://github.com/jsonapi-suite/ember-data-extensions/blob/master/addon/mixins/model.js#L4) to fail.

The second change is to add a method for unmarking a model for destruction. We have a form where the user can toggle between two options (lets call them option A and option B). 

If the user selects option A, a relationship is added to the parent model. If the user selects option B, then this relationship (if it exists) is deleted. When editing the parent model, if the user switches back and forth between option A and B, we did not want to delete and recreate the same model multiple times. 

Simply toggling `_markedForDestruction` solved the problem for us. @leondmello can provide a better explanation if I'm not clear enough. 