### PR TITLE
Respect serializer keyForAttribute transform when rebuilding payload

### DIFF
--- a/addon/mixins/nested-relations.js
+++ b/addon/mixins/nested-relations.js
@@ -35,12 +35,17 @@ const attributesFor = function(record, isManyToManyDelete) {
   let attrs = {};
 
   let changes = record.changedAttributes();
+
+  let serializer = record.store.serializerFor(record.constructor.modelName);
+
   record.eachAttribute((name/* meta */) => {
+    let keyName = serializer.keyForAttribute(name);
+
     if (record.get('isNew') || changes[name]) {
       let value = record.get(name);
 
       if (value !== undefined) {
-        attrs[name] = record.get(name);
+        attrs[keyName] = record.get(name);
       }
     }
   });

--- a/tests/dummy/app/models/post.js
+++ b/tests/dummy/app/models/post.js
@@ -4,6 +4,7 @@ import ModelMixin from 'ember-data-extensions/mixins/model';
 
 export default DS.Model.extend(ModelMixin, {
   title: DS.attr('string'),
+  publishedDate: DS.attr('date'),
 
   author: DS.belongsTo('author'),
   tags: DS.hasMany('tag'),

--- a/tests/dummy/app/serializers/application.js
+++ b/tests/dummy/app/serializers/application.js
@@ -1,5 +1,8 @@
 import DS from 'ember-data';
 import NestedRelationsMixin from 'ember-data-extensions/mixins/nested-relations';
-
+import Ember from 'ember';
 export default DS.JSONAPISerializer.extend(NestedRelationsMixin, {
+  keyForAttribute(key /* relationship, method */) {
+    return Ember.String.underscore(key);
+  }
 });

--- a/tests/unit/mixins/nested-relations-test.js
+++ b/tests/unit/mixins/nested-relations-test.js
@@ -34,6 +34,7 @@ const Genre = DS.Model.extend(ModelMixin, NestedRelationsMixin, {
 
 const Post = DS.Model.extend(ModelMixin, NestedRelationsMixin, {
   title: DS.attr('string'),
+  publishedDate: DS.attr('date'),
   genre: DS.belongsTo(),
   author: DS.belongsTo(),
   asyncFalseAuthor: DS.belongsTo('author', { async: false }),
@@ -144,6 +145,23 @@ test('it serializes basic attributes correctly', function(assert) {
       type: 'posts',
       attributes: {
         title: 'test post'
+      }
+    }
+  };
+
+  assert.deepEqual(json, expectedJSON, 'has correct json');
+});
+
+test('it respects custom keyForAttribute settings in serializer', function(assert) {
+  let date = new Date();
+  let post = store.createRecord('post', { publishedDate: date });
+  let json = serialize(post, {});
+
+  let expectedJSON = {
+    data: {
+      type: 'posts',
+      attributes: {
+        published_date: date // serializer transforms to underscores
       }
     }
   };


### PR DESCRIPTION
This might be a small symptom of a larger issue, but one thing that bit me when integrating this with a rails API was that when serializing it didn't pay attention to the base serializer settings—specifically the `keyForAttribute` transform, meaning that camelcased multi-word attributes on ember models (like `publishedDate` in the added test) wouldn't get serialized correctly as `published_date` and would instead show up as `publishedDate` in the emitted json.