### PR TITLE
Set repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "ember server",
     "test": "ember try:each"
   },
-  "repository": "",
+  "repository": "https://github.com/jsonapi-suite/ember-data-extensions",
   "engines": {
     "node": ">= 0.10.0"
   },


### PR DESCRIPTION
This lets sites like Ember Observer fetch additional information about the addon.